### PR TITLE
Fix issue where non-existing thumbs are created.

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -103,8 +103,10 @@ _V_.Playlist = _V_.Component.extend({
     this.wrapperEl = this._super("div", { className: "playlist-wrapper" })
 
     for (i in this.videos) {
-      var thumb = new _V_.PlaylistThumb(this.player, this.videos[i], i)
-      this.wrapperEl.appendChild(thumb.el);
+      if (this.videos.hasOwnProperty(i)) {
+        var thumb = new _V_.PlaylistThumb(this.player, this.videos[i], i)
+        this.wrapperEl.appendChild(thumb.el);
+      }
     };
 
     // add playlist-wrapper to main playlist tag


### PR DESCRIPTION
`_V_.Playlist` createElement has an issue where it's looping through the `videos` property to create the thumbs, but it's using a for-in loop without a check for hasOwnProperty, which just makes a thumb for every property in the `videos` prototype chain.
